### PR TITLE
WebQueryModule for web api access

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -212,10 +212,10 @@ class AppModule extends AbstractModule
     {
         // WebQueryModuleインストール
         $webQueryConfig = [
-            'todo_post' => ['POST', 'https://httpbin.org/todo'],
+            'todo_post' => ['POST', 'https://httpbin.org/todo'], // bind-name => [method, uri]
             'todo_get' => ['GET', 'https://httpbin.org/todo']
         ];
-        $guzzleConfig = [];
+        $guzzleConfig = []; // @see http://docs.guzzlephp.org/en/stable/request-options.html
         $this->install(new WebQueryModule($webQueryConfig, $guzzleConfig));
     }
 }
@@ -248,6 +248,9 @@ public function __construct(
 ```
 
 `@AliasQuery`の利用コードも変わりません。
+
+## クライアントオプション
+
 
 ## PHPクラスを束縛
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ class AppModule extends AbstractModule
 
         // WebQueryModule install
         $webQueryConfig = [
-            'post_todo' => ['POST', 'https://httpbin.org/todo'],
+            'post_todo' => ['POST', 'https://httpbin.org/todo'], // bind-name => [method, uri]
             'get_todo' => ['GET', 'https://httpbin.org/todo']
         ];
-        $guzzleConfig = [];
+        $guzzleConfig = []; // @see http://docs.guzzlephp.org/en/stable/request-options.html
         $this->install(new WebQueryModule($webQueryConfig, $guzzleConfig));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
         "php": ">=7.1.0",
         "ray/di": "^2.6.6",
-        "ray/aura-sql-module": "^1.6"
+        "ray/aura-sql-module": "^1.6",
+        "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",

--- a/src/Annotation/GuzzleConfig.php
+++ b/src/Annotation/GuzzleConfig.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the Ray.Query.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Query\Annotation;
+
+/**
+ * Annotates your class methods into which the Injector should inject values
+ *
+ * @Annotation
+ */
+final class GuzzleConfig
+{
+}

--- a/src/Exception/WebQueryException.php
+++ b/src/Exception/WebQueryException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the Ray.Query.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Query\Exception;
+
+class WebQueryException extends \RuntimeException
+{
+}

--- a/src/WebQuery.php
+++ b/src/WebQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the Ray.Query.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Query;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Ray\Query\Exception\WebQueryException;
+
+final class WebQuery implements QueryInterface
+{
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var string
+     */
+    private $method;
+
+    /**
+     * @var string
+     */
+    private $uri;
+
+    public function __construct(ClientInterface $client, string $method, string $uri)
+    {
+        $this->client = $client;
+        $this->method = $method;
+        $this->uri = $uri;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __invoke(array $query) : iterable
+    {
+        try {
+            $response = $this->client->request($this->method, $this->uri, ['query' => $query]);
+            $body = $response->getBody()->getContents();
+
+            return json_decode($body, true);
+        } catch (GuzzleException $e) {
+            throw new WebQueryException($e->getMessage(), 0, $e);
+        }
+    }
+}

--- a/src/WebQueryModule.php
+++ b/src/WebQueryModule.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the Ray.Query.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Query;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use Ray\Di\AbstractModule;
+use Ray\Di\Scope;
+use Ray\Query\Annotation\GuzzleConfig;
+
+class WebQueryModule extends AbstractModule
+{
+    /**
+     * @var array
+     */
+    private $guzzleConfig;
+    /**
+     * @var array
+     */
+    private $webQueryConfig;
+
+    public function __construct(array $webQueryConfig, array $guzzleConfig, AbstractModule $module = null)
+    {
+        $this->guzzleConfig = $guzzleConfig;
+        $this->webQueryConfig = $webQueryConfig;
+        parent::__construct($module);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->configureClient();
+        foreach ($this->webQueryConfig as $name => $value) {
+            list($method, $uri) = $value;
+            $this->configureWebQuery($name, $method, $uri);
+        }
+    }
+
+    private function configureWebQuery(string $name, string $method, string $uri)
+    {
+        $prefixedName = 'wq-' . $name;
+        $this
+            ->bind(QueryInterface::class)
+            ->annotatedWith($name)
+            ->toConstructor(
+                WebQuery::class,
+                [
+                    'method' => $prefixedName . '-method',
+                    'uri' => $prefixedName . '-uri',
+                ]
+            );
+        $this
+            ->bind()
+            ->annotatedWith($name)
+            ->toConstructor(
+                WebQuery::class,
+                [
+                    'method' => $prefixedName . '-method',
+                    'uri' => $prefixedName . '-uri',
+                ]
+            );
+        $this->bind()->annotatedWith($prefixedName . '-method')->toInstance($method);
+        $this->bind()->annotatedWith($prefixedName . '-uri')->toInstance($uri);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function configureClient()
+    {
+        $this
+            ->bind(ClientInterface::class)
+            ->toConstructor(
+                Client::class,
+                ['config' => GuzzleConfig::class]
+            )->in(Scope::SINGLETON);
+        $this->bind()->annotatedWith(GuzzleConfig::class)->toInstance($this->guzzleConfig);
+    }
+}

--- a/src/WebQueryModule.php
+++ b/src/WebQueryModule.php
@@ -67,6 +67,26 @@ class WebQueryModule extends AbstractModule
                     'uri' => $prefixedName . '-uri',
                 ]
             );
+        $this
+            ->bind(RowInterface::class)
+            ->annotatedWith($name)
+            ->toConstructor(
+                WebQuery::class,
+                [
+                    'method' => $prefixedName . '-method',
+                    'uri' => $prefixedName . '-uri',
+                ]
+            );
+        $this
+            ->bind(RowListInterface::class)
+            ->annotatedWith($name)
+            ->toConstructor(
+                WebQuery::class,
+                [
+                    'method' => $prefixedName . '-method',
+                    'uri' => $prefixedName . '-uri',
+                ]
+            );
         $this->bind()->annotatedWith($prefixedName . '-method')->toInstance($method);
         $this->bind()->annotatedWith($prefixedName . '-uri')->toInstance($uri);
     }

--- a/tests/WebQueryModuleTest.php
+++ b/tests/WebQueryModuleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the Ray.Query.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Query;
+
+use MongoDB\Driver\Query;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
+
+class WebQueryModuleTest extends TestCase
+{
+    /**
+     * @var AbstractModule
+     */
+    private $module;
+
+    public function setUp()
+    {
+        $webQueryConfig = [
+            'foo' => ['GET', 'https://httpbin.org/anything/foo'],
+            'bar' => ['GET', 'https://httpbin.org/anything/bar']
+        ];
+        $guzzleConfig = [];
+        $this->module = new WebQueryModule($webQueryConfig, $guzzleConfig);
+    }
+
+    public function testQueryInterface()
+    {
+        $foo = (new Injector($this->module))->getInstance(QueryInterface::class, 'foo');
+        $this->assertInstanceOf(QueryInterface::class, $foo);
+        $result = $foo([]);
+        $this->assertSame('https://httpbin.org/anything/foo', $result['url']);
+    }
+
+    public function testCallable()
+    {
+        $foo = (new Injector($this->module))->getInstance('', 'foo');
+        $this->assertInternalType('callable', $foo);
+        $result = $foo([]);
+        $this->assertSame('https://httpbin.org/anything/foo', $result['url']);
+    }
+}

--- a/tests/WebQueryTest.php
+++ b/tests/WebQueryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the Ray.Query.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Query;
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+use Ray\Query\Exception\WebQueryException;
+
+class WebQueryTest extends TestCase
+{
+    /**
+     * @var WebQuery
+     */
+    private $webQuery;
+
+    public function setUp()
+    {
+        $this->webQuery = new WebQuery(new Client, 'GET', 'https://httpbin.org/json');
+    }
+
+    public function test__invoke()
+    {
+        $webQuery = new WebQuery(new Client, 'GET', 'https://httpbin.org/json');
+        $result = $webQuery([]);
+        $this->assertArrayHasKey('slideshow', $result);
+    }
+
+    public function test404()
+    {
+        $this->expectException(WebQueryException::class);
+        $webQuery = new WebQuery(new Client, 'GET', 'https://httpbin.org/status/404');
+        $result = $webQuery([]);
+        $this->assertArrayHasKey('slideshow', $result);
+    }
+}


### PR DESCRIPTION

## install WebQueryModule module

```php
use Ray\Di\AbstractModule;
use Ray\Query\SqlQueryModule;

class AppModule extends AbstractModule
{
    protected function configure()
    {
        // WebQueryModule install
        $webQueryConfig = [
            'post_todo' => ['POST', 'https://example.com/todo'],
            'get_todo' => ['GET', 'https://example.com/todo']
        ];
        $guzzleConfig = [];
        $this->install(new WebQueryModule($webQueryConfig, $guzzleConfig));
    }
}
```
The usage is exactly same as SqlQueryModule.

```php
class Todo
{
    /**
     * @var callable
     */
    private $createTodo;
    
    /**
     * @var callable
     */
    private $todo;
    
    /**
     * @Named("createTodo=post_todo, todo=get_todo")
     */
    public function __construct(
        callable $createTodo,
        callable $todo
    ){
        $this->createTodo = $createTodo;
        $this->todo = $todo;
    }
    
    public function get(string $uuid)
    {
        return ($this->todo)(['id' => $uuid]);
    }

    public function create(string $uuid, string $title)
    {
        ($this->createTodo)([
            'id' => $uuid,
            'title' => $title
        ]);
    }
}
```