### PR TITLE
ISO8601 DateTime module

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -46,6 +46,9 @@ class AppModule extends AbstractModule
         ];
         $guzzleConfig = [];
         $this->install(new WebQueryModule($webQueryConfig, $guzzleConfig));
+        
+        // ISO8601 DateTimeフォーマット
+        $this->>install(new Iso8601FormatModule(['created_at', 'updated_at']);
     }
 }
 ```
@@ -280,6 +283,15 @@ $this->bind('')->annotatedWith('cretate_todo')->to(CreateTodo::class); // callab
 ```
 
 利用コードは同じです。`@AliasQuery`の利用コードも変わりません。
+
+## ISO8601 DateTimeモジュール
+
+指定したコラム名の値を[ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html)形式に変換します。PHPでは[DateTime::ATOM](https://www.php.net/manual/ja/class.datetime.php#datetime.constants.atom)の定数で定義されているフォーマットです。
+日付のコラム名を配列にして`Iso8601FormatModule`の引数に渡してインストールします。
+
+```php
+$this->install(new Iso8601FormatModule(['created_at', 'updated_at']));
+```
 
 ## デモ
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,15 @@ $this->bind('')->annotatedWith('cretate_todo')->to(CreateTodo::class); // callab
 
 The usage codes are the same. The usage code of `@AliasQuery` does not change either.
 
+## ISO8601 DateTimeモジュール
+
+Convert the specified column name value to the [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. In PHP, it is a format defined by constants of [DateTime::ATOM](https://www.php.net/manual/en/class.datetime.php#datetime.constants.atom).
+Install date column names as an array and pass it as an argument to `Iso8601FormatModule`.
+
+```php
+$this->install(new Iso8601FormatModule(['created_at', 'updated_at']));
+```
+
 ## Demo
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,13 @@
         "php": ">=7.1.0",
         "ext-pdo": "*",
         "ext-json": "*",
-        "ray/di": "^2.6.6",
         "ray/aura-sql-module": "^1.6",
         "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
-        "squizlabs/php_codesniffer": "^3.2",
-        "friendsofphp/php-cs-fixer": "^2.11",
-        "phpmd/phpmd": "^2.6",
-        "phpstan/phpstan-shim": "^0.11",
         "bear/resource": "^1.9.2",
+        "ray/di": "^2.8.1",
         "ray/aop": "^2.7",
         "bear/cs": "^1.1"
     },
@@ -47,19 +43,19 @@
         "test": ["vendor/bin/phpunit"],
         "tests": [
             "@cs",
-            "vendor/bin/phpmd src text ./phpmd.xml",
-            "vendor/bin/phpstan analyse -l max src tests -c phpstan.neon --no-progress",
+            "phpmd src text ./phpmd.xml",
+            "phpstan analyse -l max src tests -c phpstan.neon --no-progress",
             "vendor/bin/phpunit",
             "php demo/run.php"
         ],
         "coverage": ["php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],
         "cs": [
-            "vendor/bin/php-cs-fixer fix -v --dry-run",
-            "vendor/bin/phpcs --standard=phpcs.xml src;"
+            "php-cs-fixer fix -v --dry-run",
+            "phpcs --standard=phpcs.xml src;"
         ],
         "cs-fix": [
-            "vendor/bin/php-cs-fixer fix -v",
-            "vendor/bin/phpcbf src tests"
+            "php-cs-fixer fix -v",
+            "phpcbf src tests"
         ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
         "ext-pdo": "*",
         "ext-json": "*",
         "ray/aura-sql-module": "^1.6",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3",
+        "ray/aop": "^2.8.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
         "bear/resource": "^1.9.2",
         "ray/di": "^2.8.1",
-        "ray/aop": "^2.7",
         "bear/cs": "^1.1"
     },
     "autoload": {

--- a/demo/1-constructor-injection.php
+++ b/demo/1-constructor-injection.php
@@ -15,15 +15,6 @@ use Ray\Query\SqlQueryModule;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-class AppModule extends AbstractModule
-{
-    protected function configure()
-    {
-        $this->install(new Ray\AuraSqlModule\AuraSqlModule('sqlite::memory:'));
-        $this->install(new SqlQueryModule(dirname(__DIR__ . '/sql')));
-    }
-}
-
 class Todo
 {
     /**
@@ -61,7 +52,14 @@ class Todo
     }
 }
 
-$injector = new Injector(new AppModule);
+$injector = new Injector(new class extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->install(new Ray\AuraSqlModule\AuraSqlModule('sqlite::memory:'));
+        $this->install(new SqlQueryModule(dirname(__DIR__ . '/sql')));
+    }
+});
 /** @var Todo $todo */
 $pdo = $injector->getInstance(ExtendedPdoInterface::class);
 $pdo->query('CREATE TABLE IF NOT EXISTS todo (
@@ -72,6 +70,7 @@ $todo = $injector->getInstance(Todo::class);
 $todo->create('1', 'think');
 $todo->create('2', 'walk');
 var_dump($todo->get('1'));
+
 //array(4) {
 //    'id' =>
 //  string(1) "1"

--- a/demo/2-alias-query.php
+++ b/demo/2-alias-query.php
@@ -1,6 +1,9 @@
 <?php
 
 declare(strict_types=1);
+
+namespace Ray\Query;
+
 /**
  * This file is part of the Ray.Query.
  *
@@ -8,40 +11,25 @@ declare(strict_types=1);
  */
 
 use Aura\Sql\ExtendedPdoInterface;
+use Ray\AuraSqlModule\AuraSqlModule;
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
-use Ray\Query\Annotation\AliasQuery;
 use Ray\Query\SqlQueryModule;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-class AppModule extends AbstractModule
+require_once __DIR__ . '/Todo.php';
+
+$injector = new Injector(new class extends AbstractModule
 {
     protected function configure()
     {
-        $this->install(new Ray\AuraSqlModule\AuraSqlModule('sqlite::memory:'));
+        $this->install(new AuraSqlModule('sqlite::memory:'));
         $this->install(new SqlQueryModule(dirname(__DIR__ . '/sql')));
+        $a = class_exists(Todo::class);
+        $this->bind(Todo::class);
     }
-}
-
-class Todo
-{
-    /**
-     * @AliasQuery("todo_item_by_id")
-     */
-    public function get(string $id)
-    {
-    }
-
-    /**
-     * @AliasQuery(id="todo_insert?id={uuid}", templated=true)
-     */
-    public function create(string $uuid, string $title)
-    {
-    }
-}
-
-$injector = new Injector(new AppModule);
+});
 /** @var Todo $todo */
 $pdo = $injector->getInstance(ExtendedPdoInterface::class);
 $pdo->query('CREATE TABLE IF NOT EXISTS todo (

--- a/demo/Todo.php
+++ b/demo/Todo.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Ray\Query;
+
+use Ray\Query\Annotation\AliasQuery;
+
+class Todo
+{
+    /**
+     * @AliasQuery("todo_item_by_id")
+     */
+    public function get(string $id)
+    {
+    }
+
+    /**
+     * @AliasQuery(id="todo_insert?id={uuid}", templated=true)
+     */
+    public function create(string $uuid, string $title)
+    {
+    }
+}

--- a/demo/run.php
+++ b/demo/run.php
@@ -9,4 +9,4 @@ declare(strict_types=1);
 
 passthru('php ' . __DIR__ . '/0-manual-injection.php');
 passthru('php ' . __DIR__ . '/1-constructor-injection.php');
-passthru('php ' . __DIR__ . '/2-alias-query.php');
+passthru('php ' . __DIR__ . '/2/alias-query.php');

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
     </testsuites>
     <php>
         <ini name="error_reporting" value="-1" />
+        <ini name="date.timezone" value="UTC" />
     </php>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">

--- a/src/Iso8601FormatModule.php
+++ b/src/Iso8601FormatModule.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Ray\Query;
 
 use Ray\Di\AbstractModule;
-use Ray\Query\Annotation\Iso8601;
 
 class Iso8601FormatModule extends AbstractModule
 {
@@ -27,7 +26,6 @@ class Iso8601FormatModule extends AbstractModule
 
     protected function configure()
     {
-        $this->bind('')->annotatedWith(Iso8601::class)->toInstance($this->datetimeColumns);
         $this->bind('')->annotatedWith('iso8601_date_time_columns')->toInstance($this->datetimeColumns);
         $this->bindInterceptor(
             $this->matcher->logicalOr(

--- a/src/Iso8601FormatModule.php
+++ b/src/Iso8601FormatModule.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the Ray.Query.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Query;
+
+use Ray\Di\AbstractModule;
+use Ray\Query\Annotation\Iso8601;
+
+class Iso8601FormatModule extends AbstractModule
+{
+    private $datetimeColumns;
+
+    /**
+     * @param array               $datetimeColumns
+     * @param AbstractModule|null $module
+     */
+    public function __construct(array $datetimeColumns, AbstractModule $module = null)
+    {
+        $this->datetimeColumns = $datetimeColumns;
+        parent::__construct($module);
+    }
+
+    protected function configure()
+    {
+        $this->bind('')->annotatedWith(Iso8601::class)->toInstance($this->datetimeColumns);
+        $this->bind('')->annotatedWith('iso8601_date_time_columns')->toInstance($this->datetimeColumns);
+        $this->bindInterceptor(
+            $this->matcher->logicalOr(
+                $this->matcher->subclassesOf(SqlQueryRow::class),
+                $this->matcher->subclassesOf(SqlQueryRowList::class)
+            ),
+            $this->matcher->startsWith('__invoke'),
+            [Iso8601Interceptor::class]
+        );
+    }
+}

--- a/src/Iso8601Interceptor.php
+++ b/src/Iso8601Interceptor.php
@@ -27,7 +27,6 @@ final class Iso8601Interceptor implements MethodInterceptor
     private $datetimeColumns;
 
     /**
-     * @Iso8601
      * @Named("datetimeColumns=iso8601_date_time_columns")
      * @param string[] $datetimeColumns
      */

--- a/src/Iso8601Interceptor.php
+++ b/src/Iso8601Interceptor.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the Ray.Query.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Query;
+
+use Aura\Sql\ExtendedPdoInterface;
+use function is_array;
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+use Ray\Di\Di\Named;
+use Ray\Query\Annotation\Iso8601;
+use Ray\Query\Exception\QueryNumException;
+use function count;
+use function explode;
+use function strpos;
+
+final class Iso8601Interceptor implements MethodInterceptor
+{
+    /**
+     * @var string[]
+     */
+    private $datetimeColumns;
+
+    /**
+     * @Iso8601
+     * @Named("datetimeColumns=iso8601_date_time_columns")
+     * @param string[] $datetimeColumns
+     */
+    public function __construct(array $datetimeColumns)
+    {
+        $this->datetimeColumns = $datetimeColumns;
+    }
+
+    public function invoke(MethodInvocation $invocation)
+    {
+        $list = $invocation->proceed();
+        if (! is_array($list)) {
+            return $list;
+        }
+        if ($invocation->getThis() instanceof RowInterface) {
+            return $list = $this->convert([$list])[0];
+        }
+        return $this->convert($list);
+    }
+
+    private function convert(array $list) : array
+    {
+        foreach ($list as &$row) {
+            foreach ($row as $column => &$value) {
+                if (in_array($column, $this->datetimeColumns)) {
+                    $value = (new \DateTime($value))->format(\DateTime::ATOM);
+                }
+            }
+        }
+
+        return $list;
+    }
+}

--- a/src/SqlQueryRow.php
+++ b/src/SqlQueryRow.php
@@ -10,7 +10,7 @@ namespace Ray\Query;
 
 use Aura\Sql\ExtendedPdoInterface;
 
-final class SqlQueryRow implements RowInterface
+class SqlQueryRow implements RowInterface
 {
     /**
      * @var ExtendedPdoInterface

--- a/src/SqlQueryRowList.php
+++ b/src/SqlQueryRowList.php
@@ -14,7 +14,7 @@ use function count;
 use function explode;
 use function strpos;
 
-final class SqlQueryRowList implements RowListInterface
+class SqlQueryRowList implements RowListInterface
 {
     /**
      * @var ExtendedPdoInterface

--- a/tests/Fake/FakeQuery.php
+++ b/tests/Fake/FakeQuery.php
@@ -17,7 +17,7 @@ class FakeQuery
      * @Assisted({"todo"})
      * @Named("todo=todo_item_by_id")
      */
-    public function get(string $uuid, QueryInterface $todo)
+    public function get(string $uuid, QueryInterface $todo = null)
     {
         return $todo([
             'id' => $uuid
@@ -28,7 +28,7 @@ class FakeQuery
      * @Assisted({"createTodo"})
      * @Named("createTodo=todo_insert")
      */
-    public function create(string $uuid, string $title, QueryInterface $createTodo)
+    public function create(string $uuid, string $title, QueryInterface $createTodo = null)
     {
         return $createTodo([
             'id' => $uuid,

--- a/tests/Fake/FakeQuery.php
+++ b/tests/Fake/FakeQuery.php
@@ -19,6 +19,7 @@ class FakeQuery
      */
     public function get(string $uuid, QueryInterface $todo = null)
     {
+        assert(is_callable($todo));
         return $todo([
             'id' => $uuid
         ]);
@@ -30,6 +31,7 @@ class FakeQuery
      */
     public function create(string $uuid, string $title, QueryInterface $createTodo = null)
     {
+        assert(is_callable($createTodo));
         return $createTodo([
             'id' => $uuid,
             'title' => $title

--- a/tests/Fake/FakeTodo.php
+++ b/tests/Fake/FakeTodo.php
@@ -23,17 +23,30 @@ class FakeTodo
     private $todoCreate;
 
     /**
-     * @Named("todoGet=todo_item_by_id, todoCreate=todo_insert")
+     * @var RowListInterface
      */
-    public function __construct(RowInterface $todoGet, callable $todoCreate)
+    private $todoList;
+
+    /**
+     * @Named("todoGet=todo_item_by_id, todoList=todo_list, todoCreate=todo_insert")
+     */
+    public function __construct(RowInterface $todoGet, RowListInterface $todoList, callable $todoCreate)
     {
         $this->todoGet = $todoGet;
         $this->todoCreate = $todoCreate;
+        $this->todoList = $todoList;
     }
 
     public function get(string $uuid)
     {
         return ($this->todoGet)([
+            'id' => $uuid
+        ]);
+    }
+
+    public function getList(string $uuid)
+    {
+        return ($this->todoList)([
             'id' => $uuid
         ]);
     }

--- a/tests/Fake/sql/todo_list.sql
+++ b/tests/Fake/sql/todo_list.sql
@@ -1,0 +1,1 @@
+SELECT * FROM todo

--- a/tests/Iso8601FormatModuleTest.php
+++ b/tests/Iso8601FormatModuleTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Ray\Query;
+
+use Aura\Sql\ExtendedPdo;
+use Aura\Sql\ExtendedPdoInterface;
+use function parent;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
+
+class Iso8601FormatModuleTest extends TestCase
+{
+    /**
+     * @var ExtendedPdo
+     */
+    protected $pdo;
+
+    protected $module;
+
+    protected function setUp()
+    {
+        $pdo = new ExtendedPdo('sqlite::memory:');
+        $pdo->query('CREATE TABLE IF NOT EXISTS todo (
+          id INTEGER,
+          title TEXT,
+          created_at TIMESTAMP)'
+        );
+        $pdo->perform('INSERT INTO todo (id, title, created_at) VALUES (:id, :title, :created_at)', ['id' => '1', 'title' => 'run', 'created_at' => '1970-01-01 00:00:00']);
+        $this->module = new class($pdo) extends AbstractModule {
+            private $pdo;
+
+            public function __construct(ExtendedPdo $pdo)
+            {
+                $this->pdo = $pdo;
+                parent::__construct();
+            }
+
+            protected function configure()
+            {
+                $this->bind(ExtendedPdoInterface::class)->toInstance($this->pdo);
+                $this->install(new SqlQueryModule(__DIR__ . '/Fake/sql'));
+                $this->install(new Iso8601FormatModule(['created_at']));
+            }
+        };
+    }
+    public function testItem()
+    {
+        $injector = new Injector($this->module, __DIR__ . '/tmp');
+        $todo = $injector->getInstance(FakeTodo::class);
+        /* @var \Ray\Query\FakeTodo $todo */
+        $actural = $todo->get(1);
+        $expected = [
+            'id' => '1',
+            'title' => 'run',
+            'created_at' => '1970-01-01T00:00:00+01:00'
+        ];
+        $this->assertSame($expected, $actural);
+    }
+
+    public function testList()
+    {
+        $injector = new Injector($this->module, __DIR__ . '/tmp');
+        $todo = $injector->getInstance(FakeTodo::class);
+        /* @var \Ray\Query\FakeTodo $todo */
+        $actural = $todo->getList(1);
+        $expected = [
+            [
+                'id' => '1',
+                'title' => 'run',
+                'created_at' => '1970-01-01T00:00:00+01:00'
+            ]
+        ];
+        $this->assertSame($expected, $actural);
+    }
+}

--- a/tests/Iso8601FormatModuleTest.php
+++ b/tests/Iso8601FormatModuleTest.php
@@ -17,7 +17,7 @@ class Iso8601FormatModuleTest extends TestCase
 
     protected $module;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $pdo = new ExtendedPdo('sqlite::memory:');
         $pdo->query('CREATE TABLE IF NOT EXISTS todo (

--- a/tests/Iso8601FormatModuleTest.php
+++ b/tests/Iso8601FormatModuleTest.php
@@ -4,7 +4,6 @@ namespace Ray\Query;
 
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
-use function parent;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
@@ -24,8 +23,7 @@ class Iso8601FormatModuleTest extends TestCase
         $pdo->query('CREATE TABLE IF NOT EXISTS todo (
           id INTEGER,
           title TEXT,
-          created_at TIMESTAMP)'
-        );
+          created_at TIMESTAMP)');
         $pdo->perform('INSERT INTO todo (id, title, created_at) VALUES (:id, :title, :created_at)', ['id' => '1', 'title' => 'run', 'created_at' => '1970-01-01 00:00:00']);
         $this->module = new class($pdo) extends AbstractModule {
             private $pdo;

--- a/tests/Iso8601FormatModuleTest.php
+++ b/tests/Iso8601FormatModuleTest.php
@@ -51,7 +51,7 @@ class Iso8601FormatModuleTest extends TestCase
         $expected = [
             'id' => '1',
             'title' => 'run',
-            'created_at' => '1970-01-01T00:00:00+01:00'
+            'created_at' => '1970-01-01T00:00:00+00:00'
         ];
         $this->assertSame($expected, $actural);
     }
@@ -66,7 +66,7 @@ class Iso8601FormatModuleTest extends TestCase
             [
                 'id' => '1',
                 'title' => 'run',
-                'created_at' => '1970-01-01T00:00:00+01:00'
+                'created_at' => '1970-01-01T00:00:00+00:00'
             ]
         ];
         $this->assertSame($expected, $actural);

--- a/tests/Iso8601InterceptorTest.php
+++ b/tests/Iso8601InterceptorTest.php
@@ -22,7 +22,7 @@ class Iso8601InterceptorTest extends TestCase
         $interceptor = new Iso8601Interceptor(['created']);
         $invocation = new ReflectiveMethodInvocation($object, 'run', [], [$interceptor]);
         $result = $invocation->proceed();
-        $this->assertSame('1970-01-01T00:00:00+01:00', $result[0]['created']);
+        $this->assertSame('1970-01-01T00:00:00+00:00', $result[0]['created']);
     }
 
     public function testRowInterfaceConvert()
@@ -41,6 +41,6 @@ class Iso8601InterceptorTest extends TestCase
         $interceptor = new Iso8601Interceptor(['created']);
         $invocation = new ReflectiveMethodInvocation($object, '__invoke', [], [$interceptor]);
         $result = $invocation->proceed();
-        $this->assertSame('1970-01-01T00:00:00+01:00', $result['created']);
+        $this->assertSame('1970-01-01T00:00:00+00:00', $result['created']);
     }
 }

--- a/tests/Iso8601InterceptorTest.php
+++ b/tests/Iso8601InterceptorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Ray\Query;
+
+use function date;
+use PHPUnit\Framework\TestCase;
+use Ray\Aop\ReflectiveMethodInvocation;
+
+class Iso8601InterceptorTest extends TestCase
+{
+
+    public function testDateTimeFieldConvertedIso8601()
+    {
+        $object = new class {
+            public function run()
+            {
+                return [
+                    ['created' => '1970-01-01 00:00:00']
+                ];
+            }
+        };
+        $interceptor = new Iso8601Interceptor(['created']);
+        $invocation = new ReflectiveMethodInvocation($object, 'run', [], [$interceptor]);
+        $result = $invocation->proceed();
+        $this->assertSame('1970-01-01T00:00:00+01:00', $result[0]['created']);
+    }
+
+    public function testRowInterfaceConvert()
+    {
+        $object = new class implements RowInterface {
+
+            public function __invoke(array ...$query) : iterable
+            {
+                return ['created' => '1970-01-01 00:00:00'];
+            }
+
+            public function run()
+            {
+            }
+        };
+        $interceptor = new Iso8601Interceptor(['created']);
+        $invocation = new ReflectiveMethodInvocation($object, '__invoke', [], [$interceptor]);
+        $result = $invocation->proceed();
+        $this->assertSame('1970-01-01T00:00:00+01:00', $result['created']);
+    }
+}

--- a/tests/PhpQueryModuleTest.php
+++ b/tests/PhpQueryModuleTest.php
@@ -22,7 +22,7 @@ class PhpQueryModuleTest extends TestCase
             {
                 $this->bind()->annotatedWith('todo_item_by_id')->to(FakePhpQuery::class);
             }
-        });
+        }, __DIR__ . '/tmp');
         $foo = $injector->getInstance(FakeFoo::class);
         $query = ['id' => '1'];
         $this->assertSame($query, $foo(['id' => '1']));
@@ -38,7 +38,7 @@ class PhpQueryModuleTest extends TestCase
                 ];
                 $this->install(new PhpQueryModule($queryBindings));
             }
-        });
+        }, __DIR__ . '/tmp');
         $foo = $injector->getInstance(FakeFoo::class);
         $query = ['id' => '1'];
         $this->assertSame($query, $foo($query));

--- a/tests/SqlQueryModuleTest.php
+++ b/tests/SqlQueryModuleTest.php
@@ -49,7 +49,7 @@ class SqlQueryModuleTest extends TestCase
 
     public function testRowInterfaceInject()
     {
-        $injector = new Injector($this->module);
+        $injector = new Injector($this->module, __DIR__ . '/tmp');
         $todo = $injector->getInstance(FakeTodo::class);
         /* @var \Ray\Query\FakeQuery $todo */
         $actual = $todo->create('2', 'think');
@@ -58,7 +58,7 @@ class SqlQueryModuleTest extends TestCase
 
     public function testCallableInject()
     {
-        $injector = new Injector($this->module);
+        $injector = new Injector($this->module, __DIR__ . '/tmp');
         $todo = $injector->getInstance(FakeTodo::class);
         /* @var \Ray\Query\FakeQuery $todo */
         $actural = $todo->get('1');
@@ -71,7 +71,7 @@ class SqlQueryModuleTest extends TestCase
 
     public function testAssistedQueryInterface()
     {
-        $injector = new Injector($this->module);
+        $injector = new Injector($this->module, __DIR__ . '/tmp');
         $todo = $injector->getInstance(FakeQuery::class);
         /* @var \Ray\Query\FakeQuery $todo */
         $actual = $todo->create('2', 'think');
@@ -80,7 +80,7 @@ class SqlQueryModuleTest extends TestCase
 
     public function testAssistedQuery()
     {
-        $injector = new Injector($this->module);
+        $injector = new Injector($this->module, __DIR__ . '/tmp');
         $todo = $injector->getInstance(FakeQuery::class);
         /* @var \Ray\Query\FakeQuery $todo */
         $actual = $todo->get('1')[0]['title'];
@@ -89,7 +89,7 @@ class SqlQueryModuleTest extends TestCase
 
     public function testRowInterface()
     {
-        $injector = new Injector($this->module);
+        $injector = new Injector($this->module, __DIR__ . '/tmp');
         $item = $injector->getInstance(FakeItem::class);
         /* @var \Ray\Query\FakeItem $item */
         $actual = $item(['id' => '1']);
@@ -98,7 +98,7 @@ class SqlQueryModuleTest extends TestCase
 
     public function testRowListInterface()
     {
-        $injector = new Injector($this->module);
+        $injector = new Injector($this->module, __DIR__ . '/tmp');
         $item = $injector->getInstance(FakeList::class);
         /* @var \Ray\Query\FakeItem $item */
         $actual = $item(['id' => '1']);
@@ -107,7 +107,7 @@ class SqlQueryModuleTest extends TestCase
 
     public function testSqlAliasInterceptor()
     {
-        $injector = new Injector($this->module);
+        $injector = new Injector($this->module, __DIR__ . '/tmp');
         /* @var \Ray\Query\FakeAlias $fakeAlias */
         $fakeAlias = $injector->getInstance(FakeAlias::class);
         $actual = $fakeAlias->get('1');
@@ -120,7 +120,7 @@ class SqlQueryModuleTest extends TestCase
 
     public function testSqlAliasInterceptorWithNamed()
     {
-        $injector = new Injector($this->module);
+        $injector = new Injector($this->module, __DIR__ . '/tmp');
         /* @var \Ray\Query\FakeAlias $fakeAlias */
         $fakeAlias = $injector->getInstance(FakeAliasNamed::class);
         $actual = $fakeAlias->get('1');

--- a/tests/SqlQueryModuleTest.php
+++ b/tests/SqlQueryModuleTest.php
@@ -23,7 +23,7 @@ class SqlQueryModuleTest extends TestCase
 
     protected $module;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $pdo = new ExtendedPdo('sqlite::memory:');
         $pdo->query('CREATE TABLE IF NOT EXISTS todo (

--- a/tests/SqlQueryTest.php
+++ b/tests/SqlQueryTest.php
@@ -15,7 +15,7 @@ class SqlQueryTest extends TestCase
 {
     private $pdo;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $pdo = new ExtendedPdo('sqlite::memory:');
         $pdo->query('CREATE TABLE IF NOT EXISTS todo (

--- a/tests/WebQueryModuleTest.php
+++ b/tests/WebQueryModuleTest.php
@@ -31,7 +31,7 @@ class WebQueryModuleTest extends TestCase
 
     public function testQueryInterface()
     {
-        $foo = (new Injector($this->module))->getInstance(QueryInterface::class, 'foo');
+        $foo = (new Injector($this->module, __DIR__ . '/tmp'))->getInstance(QueryInterface::class, 'foo');
         $this->assertInstanceOf(QueryInterface::class, $foo);
         $result = $foo([]);
         $this->assertSame('https://httpbin.org/anything/foo', $result['url']);
@@ -39,7 +39,7 @@ class WebQueryModuleTest extends TestCase
 
     public function testCallable()
     {
-        $foo = (new Injector($this->module))->getInstance('', 'foo');
+        $foo = (new Injector($this->module, __DIR__ . '/tmp'))->getInstance('', 'foo');
         $this->assertInternalType('callable', $foo);
         $result = $foo([]);
         $this->assertSame('https://httpbin.org/anything/foo', $result['url']);

--- a/tests/WebQueryModuleTest.php
+++ b/tests/WebQueryModuleTest.php
@@ -19,7 +19,7 @@ class WebQueryModuleTest extends TestCase
      */
     private $module;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $webQueryConfig = [
             'foo' => ['GET', 'https://httpbin.org/anything/foo'],

--- a/tests/WebQueryTest.php
+++ b/tests/WebQueryTest.php
@@ -19,7 +19,7 @@ class WebQueryTest extends TestCase
      */
     private $webQuery;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->webQuery = new WebQuery(new Client, 'GET', 'https://httpbin.org/json');
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,4 +13,4 @@ $rm = function ($dir) use (&$rm) {
         @rmdir($f);
     }
 };
-$rm(sys_get_temp_dir());
+$rm(__DIR__ . '/tmp');


### PR DESCRIPTION
# ISO8601 DateTimeモジュール

指定したコラム名の値を[ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html)形式に変換します。PHPでは[DateTime::ATOM](https://www.php.net/manual/ja/class.datetime.php#datetime.constants.atom)の定数で定義されているフォーマットです。
日付のコラム名を配列にして`Iso8601FormatModule`の引数に渡してインストールします。mysqlのdatetimeカラムの値をJSONで標準的なISO8601に変換します。

```php
$this->install(new Iso8601FormatModule(['created_at', 'updated_at']));
```
