### PR TITLE
複数行にまたがるSQLの最終行がSELECT文の場合に値が返ってこない

### DIFF
--- a/src/SqlQueryRowList.php
+++ b/src/SqlQueryRowList.php
@@ -39,13 +39,16 @@ class SqlQueryRowList implements RowListInterface
         if (count($sqls) !== $numQueris) {
             throw new QueryNumException($this->sql);
         }
+        $result = null;
         for ($i = 0; $i < $numQueris; $i++) {
             $sql = $sqls[$i];
             $query = $queries[$i];
             $result = $this->pdo->perform($sql, $query);
         }
-        $lastQuery = isset($result) ? strtolower(trim($result->queryString, "\\ \t\n\r\0\x0B")) : '';
-        if ($lastQuery && strpos($lastQuery, 'select') === 0) {
+        $lastQuery = $result
+            ? strtolower(trim($result->queryString, "\\ \t\n\r\0\x0B"))
+            : '';
+        if ($result instanceof \PDOStatement && strpos($lastQuery, 'select') === 0) {
             return (array) $result->fetchAll(\PDO::FETCH_ASSOC);
         }
 

--- a/src/SqlQueryRowList.php
+++ b/src/SqlQueryRowList.php
@@ -44,7 +44,8 @@ class SqlQueryRowList implements RowListInterface
             $query = $queries[$i];
             $result = $this->pdo->perform($sql, $query);
         }
-        if (isset($result) && strpos(strtolower($result->queryString), 'select') === 0) {
+        $lastQuery = isset($result) ? strtolower(trim($result->queryString, "\\ \t\n\r\0\x0B")) : '';
+        if ($lastQuery && strpos($lastQuery, 'select') === 0) {
             return (array) $result->fetchAll(\PDO::FETCH_ASSOC);
         }
 

--- a/tests/Fake/sql/multiple_query.sql
+++ b/tests/Fake/sql/multiple_query.sql
@@ -1,0 +1,3 @@
+INSERT INTO todo (id, title) VALUES (:id, :title);
+
+SELECT * FROM todo WHERE id = :id;

--- a/tests/SqlQueryTest.php
+++ b/tests/SqlQueryTest.php
@@ -38,4 +38,21 @@ class SqlQueryTest extends TestCase
         $row = $query(['id' => '__invalid__']);
         $this->assertSame([], $row);
     }
+
+    public function testMultipleQuery()
+    {
+        $sql = (string) file_get_contents(__DIR__ . '/Fake/sql/multiple_query.sql');
+        $query = new SqlQueryRowList($this->pdo, $sql);
+        $row = ((array) $query(
+            [
+                'id' => 2,
+                'title' => 'test'
+            ],
+            [
+                'id' => 2
+            ]
+        ))[0];
+        $this->assertSame('test', $row['title']);
+        $this->assertSame('2', $row['id']);
+    }
 }


### PR DESCRIPTION
以下のような複数行にまたがるSQLの最終行が SELECT 文の場合に、 `SqlQueryRowList` は値を返すような想定になっているとおもうのですが、改行等が入っていると最後のSELECT文が発行されませんでした。

```sql
INSERT INTO todo (
  title
  , completed
)
VALUES (
  :title
  , :completed
);

SELECT @todo_id := last_insert_id();

INSERT INTO todo_user (
  user_id
  , todo_id
)
VALUES (
  :user_id
  , @todo_id
);

SELECT * FROM todo WHERE id = @todo_id;
```

原因としては https://github.com/ray-di/Ray.QueryModule/blob/f238f109ba403a4c0fa3213ecce45149a836ee26/src/SqlQueryRowList.php#L47 の分岐で `$result->queryString` に改行込みでSQL文が入っているため、 `strpos` 判定に失敗するためと思われます。