### PR TITLE
[BC break] Change default query type "row_list"

### DIFF
--- a/src/Annotation/Query.php
+++ b/src/Annotation/Query.php
@@ -39,7 +39,7 @@ final class Query
      */
     public $type = 'row_list';
 
-    public function __construct(string $id, string $type = 'row', bool $templated = false)
+    public function __construct(string $id, string $type = 'row_list', bool $templated = false)
     {
         $this->id = $id;
         $this->templated = $templated;


### PR DESCRIPTION
このPRは`@Query`アノテーションまたは`#[Query]`アトリビュートで`type`を指定していない場合のデフォルトをrow_listに修正します。以前は`row`になっていました。

* `NamedArgumentConstructor`に対応してなかった場合は変更なし
* `NamedArgumentConstructor`に対応していて、`type`を指定していない場合には以前は`row`だったものが`rowList`になり互換性が破壊されます。
* `NamedArgumentConstructor`に対応していて、`type`を指定した場合には影響がありません。

