### PR TITLE
Enable PHP 8.4 compat

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,6 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.3", "7.4", "8.0", "8.1", "8.2"]'
-      current_stable: 8.3
+      old_stable: '["7.3", "7.4", "8.0", "8.1", "8.2", , "8.31"]'
+      current_stable: 8.4
       script: demo/run.php


### PR DESCRIPTION
Expanded the `old_stable` versions array to include 8.31 and updated `current_stable` to version 8.4. This ensures compatibility testing with the latest PHP versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a syntax error in the configuration affecting the CI workflow.
- **Chores**
	- Updated the stable PHP version parameters in the CI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->