### PR TITLE
Remove koriym/param-reader dependency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,10 +23,12 @@ jobs:
           # PHP 8.3
           - {php-version: "8.3", os: ubuntu-latest, dependencies: highest}
           - {php-version: "8.3", os: ubuntu-latest, dependencies: lowest}
-          # PHP 8.4 (current stable)
-          # aura/sql 5.x (lowest) is skipped on PHP 8.4: PDO::connect() static/non-static conflict (upstream bug)
-          - {php-version: "8.4", os: windows-latest, dependencies: highest}
-          - {php-version: "8.4", os: ubuntu-latest,  dependencies: highest}
+          # PHP 8.4
+          # aura/sql 5.x (lowest) is skipped on PHP 8.4+: PDO::connect() static/non-static conflict (upstream bug)
+          - {php-version: "8.4", os: ubuntu-latest, dependencies: highest}
+          # PHP 8.5
+          - {php-version: "8.5", os: windows-latest, dependencies: highest}
+          - {php-version: "8.5", os: ubuntu-latest,  dependencies: highest}
 
     steps:
       - name: Disable autocrlf on Windows

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,4 +9,4 @@ jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
-      php_version: 8.4
+      php_version: 8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.11.1] - 2026-03-03
+
+### Removed
+- `koriym/param-reader` dependency — replaced with native `ReflectionParameter::getAttributes()`
+
+## [0.11.0] - 2026-03-01
+
+### Added
+- PHP 8.2, 8.3, and 8.4 support
+
+### Changed
+- **Require PHP ^8.2** — dropped PHP 8.1 (EOL December 2024)
+- Replaced `doctrine/annotations` with native PHP 8 Attributes for all annotation classes
+- Upgraded `vimeo/psalm` to v6
+- Tightened `ray/di` constraint to `^2.20` (parameter-level `#[Named]` requires 2.20+)
+- Upgraded `aura/sql` constraint to `^5.0.3 | ^6.0`
+
+### Removed
+- `doctrine/annotations` dependency
+
+## [0.10.0] - 2024-12-18
+
+### Added
+- PHP 8.4 support
+- Fix SQL with comments can be executed ([#33](https://github.com/ray-di/Ray.QueryModule/pull/33))
+
+### Changed
+- Refactored type annotations for query result handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.1] - 2026-03-03
 
+### Added
+- PHP 8.5 support
+
 ### Removed
 - `koriym/param-reader` dependency — replaced with native `ReflectionParameter::getAttributes()`
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "aura/sql": "^5.0.3 | ^6.0",
         "bear/resource": "^1.15",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "koriym/param-reader": "^1.0",
         "koriym/query-locator": "^1.4",
         "nikic/php-parser": "^v4.13",
         "ray/aop": "^2.10.3",

--- a/src/SqlFinder.php
+++ b/src/SqlFinder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Ray\Query;
 
-use Koriym\ParamReader\ParamReaderInterface;
 use Ray\Query\Annotation\Sql;
 use Ray\Query\Exception\SqlFileNotFoundException;
 use Ray\Query\Exception\SqlNotAnnotatedException;
@@ -17,28 +16,19 @@ use function sprintf;
 /** @psalm-api */
 final class SqlFinder
 {
-    /** @var ParamReaderInterface<object> */
-    private $reader;
-
-    /** @var SqlDir */
-    private $sqlDir;
-
-    /** @param ParamReaderInterface<object> $reader */
     public function __construct(
-        ParamReaderInterface $reader,
-        SqlDir $sqlDir
+        private readonly SqlDir $sqlDir,
     ) {
-        $this->reader = $reader;
-        $this->sqlDir = $sqlDir;
     }
 
     public function __invoke(ReflectionParameter $param): string
     {
-        /** @var ?Sql $sqlAnnotation */
-        $sqlAnnotation = $this->reader->getParametrAnnotation($param, Sql::class);
-        if ($sqlAnnotation === null) {
+        $attrs = $param->getAttributes(Sql::class);
+        if ($attrs === []) {
             throw new SqlNotAnnotatedException((string) $param);
         }
+
+        $sqlAnnotation = $attrs[0]->newInstance();
 
         $file = sprintf('%s/%s.sql', $this->sqlDir->value, $sqlAnnotation->sql);
         if (! file_exists($file)) {

--- a/src/SqlQueryProviderModule.php
+++ b/src/SqlQueryProviderModule.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Ray\Query;
 
-use Koriym\ParamReader\ParamReader;
-use Koriym\ParamReader\ParamReaderInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 
@@ -23,7 +21,6 @@ final class SqlQueryProviderModule extends AbstractModule
     protected function configure()
     {
         $this->bind(SqlFinder::class)->in(Scope::SINGLETON);
-        $this->bind(ParamReaderInterface::class)->to(ParamReader::class)->in(Scope::SINGLETON);
         $this->bind(RowInterface::class)->toProvider(RowInterfaceProvider::class)->in(Scope::SINGLETON);
         $this->bind(RowListInterface::class)->toProvider(RowListInterfaceProvider::class)->in(Scope::SINGLETON);
         $this->bind(InvokeInterface::class)->toProvider(RowListInterfaceProvider::class)->in(Scope::SINGLETON);


### PR DESCRIPTION
## Summary
- Remove `koriym/param-reader` dependency (no longer needed after doctrine/annotations removal)
- Replace `ParamReaderInterface` in `SqlFinder` with native `ReflectionParameter::getAttributes()`
- Remove `ParamReaderInterface` binding from `SqlQueryProviderModule`

## Test plan
- ✅ `composer tests` (cs + sa + test) all pass
- ✅ 32 tests, 60 assertions OK
- ✅ PHPStan / Psalm: no errors

## Summary by Sourcery

Remove the external parameter reader dependency and rely on PHP native attributes for SQL query discovery.

Enhancements:
- Refactor SqlFinder to resolve Sql annotations via ReflectionParameter attributes instead of an external ParamReader service.

Build:
- Remove koriym/param-reader from composer dependencies.

Chores:
- Drop the ParamReaderInterface binding from SqlQueryProviderModule now that it is no longer used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed `koriym/param-reader` dependency from the project.
  * Refactored annotation discovery mechanism to utilize PHP 8 attributes. Existing external behavior and error handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->