### PR TITLE
Remove unused nikic/php-parser dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+- `nikic/php-parser` dependency — unused in `src/`; no `PhpParser` namespace reference exists anywhere in the codebase or its git history
+
 ## [0.11.1] - 2026-03-03
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "bear/resource": "^1.15",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "koriym/query-locator": "^1.4",
-        "nikic/php-parser": "^v4.13",
         "ray/aop": "^2.10.3",
         "ray/aura-sql-module": "^1.10.0",
         "ray/di": "^2.20"


### PR DESCRIPTION
## Summary
- `nikic/php-parser` is required in `composer.json` (`^v4.13`) but the `PhpParser` namespace is never referenced anywhere in `src/`, `src-deprecated/`, or the project's entire git history (verified with `git log -S "PhpParser"` across all commits).
- Since Psalm 6 requires `nikic/php-parser: ^5`, this unused constraint is currently the only real blocker preventing `vimeo/psalm:^6` from being installed via a normal `composer require --dev` in the main dependency tree (it currently requires a vendor-bin isolation workaround).
- Removing it from `require` has no effect on functionality: it may still be pulled in transitively as a dev dependency of `phpunit/php-code-coverage`, but it is no longer pinned to `^v4.13` by this package.

## Test plan
- [x] `composer update` — resolves cleanly, no conflicts
- [x] `composer test` (phpunit) — 32 tests, 60 assertions, all pass
- [x] `composer sa` (phpstan + psalm) — no errors
- [x] `composer cs` (phpcs) — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused dependency from the project.
  * Updated the changelog to reflect the removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->